### PR TITLE
Fix missing injection in CubaPermissionBuildHelper.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ apply(plugin: 'cuba')
 cuba {
     artifact {
         group = 'ru.udya.sharedsession'
-        version = '0.12'
+        version = '0.13'
         isSnapshot = true
     }
 }

--- a/modules/core/test/ru/udya/sharedsession/SharedsessionTestContainer.java
+++ b/modules/core/test/ru/udya/sharedsession/SharedsessionTestContainer.java
@@ -1,12 +1,8 @@
 package ru.udya.sharedsession;
 
-import com.haulmont.bali.util.Dom4j;
 import com.haulmont.cuba.testsupport.TestContainer;
-import org.dom4j.Document;
-import org.dom4j.Element;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -14,6 +10,7 @@ public class SharedsessionTestContainer extends TestContainer {
 
     public SharedsessionTestContainer() {
         super();
+        springConfig = "ru/udya/sharedsession/test-spring.xml";
         appComponents = new ArrayList<>(Arrays.asList(
                 "com.haulmont.cuba"
                 // add CUBA premium add-ons here

--- a/modules/core/test/ru/udya/sharedsession/permission/helper/CubaPermissionBuildHelperTest.groovy
+++ b/modules/core/test/ru/udya/sharedsession/permission/helper/CubaPermissionBuildHelperTest.groovy
@@ -1,0 +1,19 @@
+package ru.udya.sharedsession.permission.helper
+
+import com.haulmont.cuba.core.global.AppBeans
+import ru.udya.sharedsession.SharedSessionIntegrationSpecification
+
+class CubaPermissionBuildHelperTest extends SharedSessionIntegrationSpecification {
+
+    private CubaPermissionBuildHelper delegate
+
+    void setup() {
+        delegate = AppBeans.get(CubaPermissionBuildHelper)
+    }
+
+    def "check that helper has required beans"() {
+        expect:
+        delegate.stringRepresentationHelper != null
+    }
+
+}

--- a/modules/core/test/ru/udya/sharedsession/test-spring.xml
+++ b/modules/core/test/ru/udya/sharedsession/test-spring.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans">
+
+    <import resource="classpath:com/haulmont/cuba/testsupport/test-spring.xml"/>
+
+    <!-- TODO: this bean should be also defined as primary in core Spring configuration, but this change requires addon users to refactor their projects for proper injection -->
+    <bean id="cuba_UserSessionManager"
+          class="ru.udya.sharedsession.sys.SharedUserSessionManager"
+          primary="true"/>
+
+</beans>

--- a/modules/global/src/ru/udya/sharedsession/permission/helper/CubaPermissionBuildHelper.java
+++ b/modules/global/src/ru/udya/sharedsession/permission/helper/CubaPermissionBuildHelper.java
@@ -12,6 +12,10 @@ public class CubaPermissionBuildHelper {
 
     protected CubaPermissionStringRepresentationHelper stringRepresentationHelper;
 
+    public CubaPermissionBuildHelper(CubaPermissionStringRepresentationHelper stringRepresentationHelper) {
+        this.stringRepresentationHelper = stringRepresentationHelper;
+    }
+
     public RoleDefinition buildRoleDefinitionBySharedUserPermissions(List<SharedUserPermission> sharedUserPermissions) {
         var roleDefinitionBuilder = BasicRoleDefinition.builder();
 


### PR DESCRIPTION
This merge request should fix missing bean injection that was found with addon usage.