### PR TITLE
Change serialization for codecs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ apply(plugin: 'cuba')
 cuba {
     artifact {
         group = 'ru.udya.sharedsession'
-        version = '0.20.0'
+        version = '0.20.1'
         isSnapshot = true
     }
 }

--- a/modules/portal/src/ru/udya/sharedsession/portal/redis/token/codec/RedisOAuth2AccessTokenCodec.java
+++ b/modules/portal/src/ru/udya/sharedsession/portal/redis/token/codec/RedisOAuth2AccessTokenCodec.java
@@ -1,11 +1,9 @@
 package ru.udya.sharedsession.portal.redis.token.codec;
 
+import com.haulmont.cuba.core.sys.serialization.SerializationSupport;
 import io.lettuce.core.codec.RedisCodec;
 import io.lettuce.core.codec.StringCodec;
-import org.apache.commons.lang3.SerializationUtils;
-import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
-import org.springframework.stereotype.Component;
 
 import java.nio.ByteBuffer;
 
@@ -20,7 +18,7 @@ public class RedisOAuth2AccessTokenCodec implements RedisCodec<String, OAuth2Acc
     public OAuth2AccessToken decodeValue(ByteBuffer buf) {
         byte[] bytes = new byte[buf.remaining()];
         buf.get(bytes);
-        return SerializationUtils.deserialize(bytes);
+        return (OAuth2AccessToken) SerializationSupport.deserialize(bytes);
     }
 
     @Override
@@ -30,6 +28,6 @@ public class RedisOAuth2AccessTokenCodec implements RedisCodec<String, OAuth2Acc
 
     @Override
     public ByteBuffer encodeValue(OAuth2AccessToken value) {
-        return ByteBuffer.wrap(SerializationUtils.serialize((DefaultOAuth2AccessToken) value));
+        return ByteBuffer.wrap(SerializationSupport.serialize(value));
     }
 }

--- a/modules/portal/src/ru/udya/sharedsession/portal/redis/token/codec/RedisOAuth2AuthenticationCodec.java
+++ b/modules/portal/src/ru/udya/sharedsession/portal/redis/token/codec/RedisOAuth2AuthenticationCodec.java
@@ -1,10 +1,9 @@
 package ru.udya.sharedsession.portal.redis.token.codec;
 
+import com.haulmont.cuba.core.sys.serialization.SerializationSupport;
 import io.lettuce.core.codec.RedisCodec;
 import io.lettuce.core.codec.StringCodec;
-import org.apache.commons.lang3.SerializationUtils;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
-import org.springframework.stereotype.Component;
 
 import java.nio.ByteBuffer;
 
@@ -20,7 +19,7 @@ public class RedisOAuth2AuthenticationCodec implements RedisCodec<String, OAuth2
         byte[] bytes = new byte[buf.remaining()];
         buf.get(bytes);
 
-        return SerializationUtils.deserialize(bytes);
+        return (OAuth2Authentication) SerializationSupport.deserialize(bytes);
     }
 
     @Override
@@ -30,6 +29,6 @@ public class RedisOAuth2AuthenticationCodec implements RedisCodec<String, OAuth2
 
     @Override
     public ByteBuffer encodeValue(OAuth2Authentication value) {
-        return ByteBuffer.wrap(SerializationUtils.serialize(value));
+        return ByteBuffer.wrap(SerializationSupport.serialize(value));
     }
 }

--- a/modules/portal/src/ru/udya/sharedsession/portal/redis/token/codec/RedisOAuth2RefreshTokenCodec.java
+++ b/modules/portal/src/ru/udya/sharedsession/portal/redis/token/codec/RedisOAuth2RefreshTokenCodec.java
@@ -1,16 +1,11 @@
 package ru.udya.sharedsession.portal.redis.token.codec;
 
+import com.haulmont.cuba.core.sys.serialization.SerializationSupport;
 import io.lettuce.core.codec.RedisCodec;
 import io.lettuce.core.codec.StringCodec;
-import org.apache.commons.lang3.SerializationUtils;
-import org.springframework.security.oauth2.common.DefaultExpiringOAuth2RefreshToken;
-import org.springframework.security.oauth2.common.DefaultOAuth2RefreshToken;
 import org.springframework.security.oauth2.common.OAuth2RefreshToken;
-import org.springframework.stereotype.Component;
 
 import java.nio.ByteBuffer;
-
-import static org.apache.commons.lang3.SerializationUtils.serialize;
 
 public class RedisOAuth2RefreshTokenCodec implements RedisCodec<String, OAuth2RefreshToken> {
 
@@ -24,7 +19,7 @@ public class RedisOAuth2RefreshTokenCodec implements RedisCodec<String, OAuth2Re
         byte[] bytes = new byte[buf.remaining()];
         buf.get(bytes);
 
-        return SerializationUtils.deserialize(bytes);
+        return (OAuth2RefreshToken) SerializationSupport.deserialize(bytes);
     }
 
     @Override
@@ -34,13 +29,6 @@ public class RedisOAuth2RefreshTokenCodec implements RedisCodec<String, OAuth2Re
 
     @Override
     public ByteBuffer encodeValue(OAuth2RefreshToken value) {
-        byte[] serialize = null;
-        if (value instanceof DefaultExpiringOAuth2RefreshToken) {
-            serialize = serialize((DefaultExpiringOAuth2RefreshToken) value);
-        }
-        if (value instanceof DefaultOAuth2RefreshToken) {
-            serialize = serialize((DefaultOAuth2RefreshToken) value);
-        }
-        return serialize == null ? null : ByteBuffer.wrap(serialize);
+        return ByteBuffer.wrap(SerializationSupport.serialize(value));
     }
 }

--- a/modules/portal/test/ru/udya/sharedsession/portal/redis/token/codec/RedisCodecsTest.groovy
+++ b/modules/portal/test/ru/udya/sharedsession/portal/redis/token/codec/RedisCodecsTest.groovy
@@ -5,10 +5,10 @@ import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken
 import org.springframework.security.oauth2.common.DefaultOAuth2RefreshToken
 import org.springframework.security.oauth2.provider.OAuth2Authentication
 import org.springframework.security.oauth2.provider.OAuth2Request
+import ru.udya.sharedsession.portal.redis.token.RedisSharedTokenStoreIntegrationTest
 import ru.udya.sharedsession.portal.redis.token.TestAuthentication
-import spock.lang.Specification
 
-class RedisCodecsTest extends Specification {
+class RedisCodecsTest extends RedisSharedTokenStoreIntegrationTest {
     RedisOAuth2AuthenticationCodec authCodec
     RedisOAuth2AccessTokenCodec accessTokenCodec
     RedisOAuth2RefreshTokenCodec refreshTokenCodec


### PR DESCRIPTION
org.apache.commons.lang3.SerializationUtils.decode() may not be used with OSGi
because it causes ClassNotFoundException for com.haulmont.addon.restapi.api.auth.ExternalAuthenticationToken